### PR TITLE
Reexport mctp-estack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-mctp-estack = { git = "https://github.com/9elements/mctp-rs.git", branch = "embassy-feature", default-features = false, features = ["log"] }
-mctp = { git = "https://github.com/9elements/mctp-rs.git", branch = "embassy-feature", default-features = false }
+mctp-estack = { git = "https://github.com/9elements/mctp-rs.git", branch = "main", default-features = false, features = ["log"] }
+mctp = { git = "https://github.com/9elements/mctp-rs.git", branch = "main", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,12 @@
 
 //! This crate provides a platform agnostic MCTP stack.
 //!
-//! It utilizes the [mctp-estack]() and re-exports parts of it.
+//! It utilizes the [mctp-estack](https://docs.rs/mctp-estack/latest/mctp_estack/) and re-exports most parts of it.
 #![no_std]
 use mctp::{Eid, Error, MsgIC, MsgType, Result, Tag};
-use mctp_estack::Stack;
 
-pub use mctp_estack::AppCookie;
-pub use mctp_estack::fragment::Fragmenter;
+use mctp_estack::fragment::Fragmenter;
+pub use mctp_estack::*;
 
 pub const MAX_LISTENER_HANDLES: usize = 64;
 pub const MAX_REQUEST_HANDLES: usize = 64;


### PR DESCRIPTION
Users only have to depend on mctp-lib, which prevents issues due to multiple versions of mctp-estack.